### PR TITLE
Update base classifier requirements (#159)

### DIFF
--- a/deslib/static/stacked.py
+++ b/deslib/static/stacked.py
@@ -13,8 +13,8 @@ class StackedClassifier(BaseStaticEnsemble):
     pool_classifiers : list of classifiers (Default = None)
         The generated_pool of classifiers trained for the corresponding
         classification problem. Each base classifiers should support the method
-        "predict". If None, then the pool of classifiers is a bagging
-        classifier.
+        "predict" and "predict_proba". If None, then the pool of classifiers
+        is a bagging classifier.
 
     meta_classifier : object or None, optional (default=None)
         Classifier model used to aggregate the output of the base classifiers.


### PR DESCRIPTION
I may be off here, but it looks to me like the pool classifiers all must support `predict_proba` (see line 148). This PR updates the description.